### PR TITLE
fix(orcaslicer): preserve extracted setting icons

### DIFF
--- a/.github/workflows/dump_slicer_configs.yml
+++ b/.github/workflows/dump_slicer_configs.yml
@@ -103,9 +103,9 @@ jobs:
       continue_build: ${{ matrix.skip && 'false' || 'true' }}
       CC: gcc
       CXX: g++
-      CFLAGS: -O3 -march=x86-64-v3 -mtune=znver4 -flto=auto -ffunction-sections -fdata-sections
-      CXXFLAGS: -O3 -march=x86-64-v3 -mtune=znver4 -flto=auto -ffunction-sections -fdata-sections
-      LDFLAGS: -flto=auto -Wl,-O1,--gc-sections
+      CFLAGS: -ffunction-sections -fdata-sections
+      CXXFLAGS: -ffunction-sections -fdata-sections
+      LDFLAGS: -Wl,--gc-sections
     steps:
       - name: Checkout repository
         if: env.continue_build == 'true'

--- a/slicers/OrcaSlicer/patches/dump_configs.patch
+++ b/slicers/OrcaSlicer/patches/dump_configs.patch
@@ -338,7 +338,7 @@ index f7017cb74b..562f14dc89 100644
 +                icon_filename += ".svg";
 +                auto icon_path = Slic3r::var(icon_filename);
 +                if (icon_path != icon_filename) {
-+                    auto& this_icon_pt = icon_data_pt.put_child(page->title().ToStdString(), ptree());
++                    auto& this_icon_pt = icon_data_pt.put_child((is_subset_tab ? page->title() : optgroup->title).ToStdString(), ptree());
 +                    this_icon_pt.put("icon_filename", icon_filename);
 +                    std::ifstream icon_fstream(icon_path);
 +                    if (!icon_fstream.is_open())


### PR DESCRIPTION
## Summary
- key normal Orca setting icons by option-group title so later groups do not overwrite earlier SVGs
- keep config-dump builds free of native tuning and LTO; upstream Release semantics remain intact

## Validation
- Orca dump patch applies to v2.4.0, v2.4.1, v2.4.2, and current HEAD (4/4)
- YAML parsing and diff whitespace checks pass

The dump patch itself changes one line.